### PR TITLE
create the tomcat user at container start, and make the UID and GID configurable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+README.md
+docker-compose.yml
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,6 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     ###
-    # Tomcat user
-    ###
-    groupadd -r tomcat && \
-    useradd -g tomcat -d ${CATALINA_HOME} -s /sbin/nologin \
-        -c "Tomcat user" tomcat && \
-    ###
     # Eliminate default web applications
     ###
     rm -rf ${CATALINA_HOME}/webapps/* && \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+
+build:
+	docker build -t unidata/tomcat-docker:8 .
+
+run:
+	docker-compose up unidata-tomcat

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This Tomcat container was security hardened according to [OWASP recommendations]
 
 - Eliminated default Tomcat web applications
 - Run Tomcat with unprivileged user `tomcat` (via `entrypoint.sh`)
+- `tomcat` user will be created at container start using either UID 9001, GID 9001, or the `LOCAL_USER_ID=` and `LOCAL_GROUP_ID` env vars
 - Start Tomcat via Tomcat Security Manager (via `entrypoint.sh`)
 - All files in `CATALINA_HOME` are owned by user `tomcat` (via `entrypoint.sh`)
 - Files in `CATALINA_HOME/conf` are read only (`400`) by user `tomcat` (via `entrypoint.sh`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,12 @@ unidata-tomcat:
   image: unidata/tomcat-docker:latest
   ports:
     - "80:8080"
-  container_name: unidata-tomcat
+  container_name: unidata-tomcat-test
   volumes:
-    - ./logs/:/usr/local/tomcat/logs/
+  - ./logs/:/usr/local/tomcat/logs/
+  environment:
+    - LOCAL_USER_ID=9876
+    - LOCAL_GROUP_ID=9877
 
 ###
 # Generic Tomcat

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,20 @@ set -e
 # security manager, but inheriting containers can also start Tomcat via
 # catalina.sh
 
+USER_ID=${LOCAL_USER_ID:-9001}
+GROUP_ID=${LOCAL_GROUP_ID:-9001}
+
 if [ "$1" = 'start-tomcat.sh' ] || [ "$1" = 'catalina.sh' ]; then
+    ###
+    # Tomcat user
+    ###
+    if ! id tomcat; then
+      groupadd -r tomcat -g ${GROUP_ID}
+      useradd -g tomcat -d ${CATALINA_HOME} \
+          -u ${USER_ID} \
+          -s /sbin/nologin \
+          -c "Tomcat user" tomcat
+    fi
 
     ###
     # Change CATALINA_HOME ownership to tomcat user and tomcat group


### PR DESCRIPTION
in our case, UID and GID 1000 are "very special", and using them results in extended file attribute ACL's that mean the log and Thredds data files can't be modified without operator intervention.



may close #34