### PR TITLE
Cleanup The Way This Project Deals With server.xml

### DIFF
--- a/.org/readme.org
+++ b/.org/readme.org
@@ -71,8 +71,6 @@ This Tomcat container was security hardened according to [[https://www.owasp.org
   ~entrypoint.sh~)
 - Files in ~CATALINA_HOME/conf~ are read only (~400~) by user ~tomcat~
   (via ~entrypoint.sh~)
-- Server version information is obscured to user
-- Add secure flag in cookie
 - Container-wide ~umask~ of ~007~
 
 *** web.xml Enhancements
@@ -81,22 +79,36 @@ This Tomcat container was security hardened according to [[https://www.owasp.org
     :CUSTOM_ID: h-1BF7025D
     :END:
 
-In addition, the following changes have been made to [[./web.xml][web.xml]] from the out-of-the-box version:
+The following changes have been made to [[./web.xml][web.xml]] from the out-of-the-box version:
 
 - Added ~SAMEORIGIN~ anti-clickjacking option
 - HTTP header security filter (~httpHeaderSecurity~) uncommented/enabled
 - Cross-origin resource sharing (CORS) filtering (~CorsFilter~) added/enabled
 - Stack traces are not returned to user through ~error-page~ element.
 
+*** server.xml Enhancements
+    :PROPERTIES:
+    :CUSTOM_ID: h-BC90DBB0
+    :END:
+
+The following changes have been made to [[./server.xml][server.xml]] from the out-of-the-box version:
+
+- Server version information is obscured to user via ~server~ attribute for all ~Connector~ elements
+- ~secure~ attribute set to ~true~ for all  ~Connector~ elements
+- Shutdown port disabled
+- Digested passwords. See next section.
+
+The active ~Connector~  has ~relaxedPathChars~ and ~relaxedQueryChars~ attributes. This change may not be optimal for security, but must be done [[https://github.com/Unidata/thredds-docker/issues/209][to accommodate DAP requests]] which THREDDS and RAMADDA must perform.
+
 *** Digested Passwords
     :PROPERTIES:
     :CUSTOM_ID: h-2C497D80
     :END:
 
-This container has a ~UserDatabaseRealm~, ~Realm~ element in ~server.xml~ with a default ~CredentialHandler~ algorithm of ~SHA~. This modification is an improvement over the clear text password default that comes with the parent container (~tomcat:8.5-jre8~). Passwords defined in ~tomcat-users.xml~ must use digested passwords in the ~password~ attributes of the ~user~ elements. Generating a digested password is simple. Here is an example for the ~SHA~ digest algorithm:
+This container has a ~UserDatabaseRealm~, ~Realm~ element in ~server.xml~ with a default ~CredentialHandler~ ~algorithm~ of ~sha-512~. This modification is an improvement over the clear text password default that comes with the parent container (~tomcat:8.5-jre8~). Passwords defined in ~tomcat-users.xml~ must use digested passwords in the ~password~ attributes of the ~user~ elements. Generating a digested password is simple. Here is an example for the ~sha-512~ digest algorithm:
 
 #+BEGIN_SRC sh
-  docker run tomcat  /usr/local/tomcat/bin/digest.sh -a "SHA" mysupersecretpassword
+  docker run tomcat  /usr/local/tomcat/bin/digest.sh -a "sha-512" mysupersecretpassword
 #+END_SRC
 
 This command will yield something like:

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,17 +32,6 @@ RUN apt-get update && \
     zip -ur catalina.jar \
         org/apache/catalina/util/ServerInfo.properties && \
     rm -rf org && cd ${CATALINA_HOME} && \
-    sed -i 's/<Connector/<Connector server="Apache" secure="true"/g' \
-        ${CATALINA_HOME}/conf/server.xml && \
-    ###
-    # Ugly, embarrassing, fragile solution to adding the CredentialHandler
-    # element until we get XSLT or the equivalent figured out. True for other
-    # XML manipulations herein.
-    # https://github.com/Unidata/tomcat-docker/issues/27
-    # https://stackoverflow.com/questions/32178822/tomcat-understanding-credentialhandler
-    ##
-    sed -i 's/resourceName="UserDatabase"\/>/resourceName="UserDatabase"><CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler" algorithm="SHA" \/><\/Realm>/g' \
-        ${CATALINA_HOME}/conf/server.xml && \
     ###
     # Setting restrictive umask container-wide
     ###
@@ -108,6 +97,11 @@ RUN set -eux; \
 # Security enhanced web.xml
 ###
 COPY web.xml ${CATALINA_HOME}/conf/
+
+###
+# Security enhanced server.xml
+###
+COPY server.xml ${CATALINA_HOME}/conf/
 
 ###
 # Tomcat start script

--- a/server.xml
+++ b/server.xml
@@ -19,7 +19,7 @@
      define subcomponents such as "Valves" at this level.
      Documentation at /docs/config/server.html
  -->
-<Server port="8005" shutdown="SHUTDOWN">
+<Server port="-1" shutdown="SHUTDOWN">
   <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
   <!-- Security listener. Documentation at /docs/config/listeners.html
   <Listener className="org.apache.catalina.security.SecurityListener" />
@@ -38,7 +38,7 @@
     <!-- Editable user database that can also be used by
          UserDatabaseRealm to authenticate users
     -->
-    <Resource name="UserDatabase" auth="Container"
+    <Resource digest="SHA" name="UserDatabase" auth="Container"
               type="org.apache.catalina.UserDatabase"
               description="User database that can be updated and saved"
               factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
@@ -115,8 +115,12 @@
     -->
 
     <!-- Define an AJP 1.3 Connector on port 8009 -->
-    <Connector server="Apache" secure="true" port="8009" protocol="AJP/1.3" redirectPort="8443" />
-
+    <!--
+    <Connector server="Apache" secure="true" protocol="AJP/1.3"
+               address="::1"
+               port="8009"
+               redirectPort="8443" />
+    -->
 
     <!-- An Engine represents the entry point (within Catalina) that processes
          every request.  The Engine implementation for Tomcat stand alone
@@ -144,7 +148,7 @@
              that are performed against this UserDatabase are immediately
              available for use by the Realm.  -->
         <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
-               resourceName="UserDatabase"><CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler" algorithm="SHA" /></Realm>
+               resourceName="UserDatabase"><CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler" algorithm="sha-512" /></Realm>
       </Realm>
 
       <Host name="localhost"  appBase="webapps"


### PR DESCRIPTION
The way this project deals with `server.xml` is confusing. There is programmatic manipulations in the `Dockerfile` which are kludgy and fragile. I think the original rationale for this was to attempt to avoid maintenance of `server.xml` by this project as the `server.xml` evolved in the parent container. In retrospect, I don't think this was a very good idea. There is additionally a `server.xml` in this project which contains `relaxedQueryChars` and `relaxedPathChars` attributes (to make DAP requests happy) to serve as hints, but it never gets copied into the container leading to additional confusion. Moreover, this project already maintains a `web.xml` that is copied into the container. 

Plan:

1. Abandon programmatic manipulation of `server.xml` inside container.
2. Incorporate the changes that the programmatic manipulation intends into the `server.xml` contained in this project. 
3. Copy that `server.xml` into the container via the `Dockerfile`. 
4. Maintain `server.xml` as the `server.xml` from the parent container evolves going forward.