### PR TITLE
Gracefully handle cases where the selected USER_ID and/or GROUP_ID exist

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,16 +13,23 @@ if [ "$1" = 'start-tomcat.sh' ] || [ "$1" = 'catalina.sh' ]; then
     ###
     # Tomcat user
     ###
-    groupadd -r tomcat -g ${GROUP_ID} && \
-    useradd -u ${USER_ID} -g tomcat -d ${CATALINA_HOME} -s /sbin/nologin \
-        -c "Tomcat user" tomcat
+    # create group for GROUP_ID if one doesn't already exist
+    if ! getent group $GROUP_ID &> /dev/null; then
+      groupadd -r tomcat -g $GROUP_ID
+    fi
+    # create user for USER_ID if one doesn't already exist
+    if ! getent passwd $USER_ID &> /dev/null; then
+      useradd -u $USER_ID -g $GROUP_ID tomcat
+    fi
+    # alter USER_ID with nologin shell and CATALINA_HOME home directory
+    usermod -d "${CATALINA_HOME}" -s /sbin/nologin $(id -u -n $USER_ID)
 
     ###
     # Change CATALINA_HOME ownership to tomcat user and tomcat group
     # Restrict permissions on conf
     ###
 
-    chown -R tomcat:tomcat ${CATALINA_HOME} && find ${CATALINA_HOME}/conf \
+    chown -R $USER_ID:$GROUP_ID ${CATALINA_HOME} && find ${CATALINA_HOME}/conf \
         -type d -exec chmod 755 {} \; -o -type f -exec chmod 400 {} \;
     sync
 
@@ -36,7 +43,7 @@ if [ "$1" = 'start-tomcat.sh' ] || [ "$1" = 'catalina.sh' ]; then
         ${CATALINA_HOME}/conf/web.xml
     fi
 
-    exec gosu tomcat "$@"
+    exec gosu $USER_ID "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
Some upstream changes in the `tomcat` Docker image have broken `entrypoint.sh` because a `ubuntu` user with uid `1000` already exists in the upstream image (`entrypoint.sh` currently references a `tomcat` user explicitly).

This change uses numeric user and group ids for `chown` and `gosu` operations, and only creates a user and group for the selects user and group ids if they don't already exist. Additionally, entrypoint will set shell to nologin and home to `CATALINA_HOME` for the selected uid.