### PR TITLE
sync not needed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,7 +46,6 @@ if [ "$1" = 'start-tomcat.sh' ] || [ "$1" = 'catalina.sh' ]; then
 
     chown -R $USER_ID:$GROUP_ID ${CATALINA_HOME} && find ${CATALINA_HOME}/conf \
         -type d -exec chmod 755 {} \; -o -type f -exec chmod 400 {} \;
-    sync
 
     ###
     # Deactivate CORS filter in web.xml if DISABLE_CORS=1


### PR DESCRIPTION
closes #142

`sync` is there for historical reasons that are no longer pertinent.